### PR TITLE
Add CLI command for measuring TpuClient slot estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7559,6 +7559,7 @@ dependencies = [
  "solana-ledger",
  "solana-logger",
  "solana-net-utils",
+ "solana-poh",
  "solana-program-test",
  "solana-rpc",
  "solana-rpc-client",
@@ -7666,6 +7667,19 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-sdk",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "solana-tpu-client-test"
+version = "2.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "log",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
+ "solana-test-validator",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ members = [
     "tokens",
     "tps-client",
     "tpu-client",
+    "tpu-client-test",
     "transaction-dos",
     "transaction-metrics-tracker",
     "transaction-status",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1658,6 +1658,10 @@ impl Validator {
             .join()
             .expect("poh_timing_report_service");
     }
+
+    pub fn poh_recorder(&self) -> Arc<RwLock<PohRecorder>> {
+        self.poh_recorder.clone()
+    }
 }
 
 fn active_vote_account_exists_in_bank(bank: &Bank, vote_account: &Pubkey) -> bool {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -366,6 +366,10 @@ impl PohRecorder {
             )
     }
 
+    pub fn current_slot(&self) -> Slot {
+        self.slot_for_tick_height(self.tick_height)
+    }
+
     // Return the slot for a given tick height
     fn slot_for_tick_height(&self, tick_height: u64) -> Slot {
         // We need to subtract by one here because, assuming ticks per slot is 64,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6339,6 +6339,7 @@ dependencies = [
  "solana-ledger",
  "solana-logger",
  "solana-net-utils",
+ "solana-poh",
  "solana-program-test",
  "solana-rpc",
  "solana-rpc-client",

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -26,6 +26,7 @@ solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
 solana-logger = { workspace = true }
 solana-net-utils = { workspace = true }
+solana-poh = { workspace = true }
 solana-program-test = { workspace = true }
 solana-rpc = { workspace = true }
 solana-rpc-client = { workspace = true }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -30,6 +30,7 @@ use {
         create_new_tmp_ledger,
     },
     solana_net_utils::PortRange,
+    solana_poh::poh_recorder::PohRecorder,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_rpc_client::{nonblocking, rpc_client::RpcClient},
     solana_runtime::{
@@ -692,6 +693,14 @@ impl TestValidator {
             .faucet_addr(faucet_addr)
             .start_with_mint_address(mint_address, socket_addr_space)
             .expect("validator start failed")
+    }
+
+    pub fn current_slot(&self) -> u64 {
+        self.poh_recorder().read().unwrap().current_slot()
+    }
+
+    pub fn poh_recorder(&self) -> Arc<RwLock<PohRecorder>> {
+        self.validator.as_ref().unwrap().poh_recorder()
     }
 
     /// Create a test validator using udp for TPU.

--- a/tpu-client-test/Cargo.toml
+++ b/tpu-client-test/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-tpu-client-test"
+description = "Solana TPU Client Test"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+clap = { version = "3.1.5", features = ["cargo", "derive"] }
+log = { workspace = true }
+solana-client = { workspace = true }
+solana-logger = { workspace = true }
+solana-sdk = { workspace = true }
+solana-test-validator = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/tpu-client-test/src/main.rs
+++ b/tpu-client-test/src/main.rs
@@ -1,0 +1,45 @@
+use clap::{crate_description, crate_name, crate_version, Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[clap(name = crate_name!(),
+    version = crate_version!(),
+    about = crate_description!(),
+    rename_all = "kebab-case"
+)]
+struct TpuClientTestArgs {
+    #[clap(subcommand)]
+    pub mode: Mode,
+}
+
+#[derive(Subcommand, Debug)]
+enum Mode {
+    /// Test the TpuClient's slot estimation accuracy.
+    SlotEstimationAccuracy {
+        #[clap(
+            short,
+            long,
+            default_value_t = 0.15,
+            help = "Accuracy threshold for slot estimation"
+        )]
+        accuracy_threshold: f64,
+        #[clap(short, long, default_value_t = 100, help = "Number of samples to take")]
+        num_samples: usize,
+    },
+}
+
+mod modes;
+use modes::*;
+
+#[tokio::main]
+async fn main() {
+    solana_logger::setup_with("solana_tpu_client_test=info");
+
+    let args = TpuClientTestArgs::parse();
+
+    match args.mode {
+        Mode::SlotEstimationAccuracy {
+            accuracy_threshold,
+            num_samples,
+        } => slot_estimation_accuracy::run(accuracy_threshold, num_samples).await,
+    }
+}

--- a/tpu-client-test/src/modes/mod.rs
+++ b/tpu-client-test/src/modes/mod.rs
@@ -1,0 +1,1 @@
+pub mod slot_estimation_accuracy;

--- a/tpu-client-test/src/modes/slot_estimation_accuracy.rs
+++ b/tpu-client-test/src/modes/slot_estimation_accuracy.rs
@@ -1,0 +1,87 @@
+use {
+    log::info,
+    solana_client::{connection_cache::Protocol, nonblocking::tpu_client::LeaderTpuService},
+    solana_sdk::clock::DEFAULT_MS_PER_SLOT,
+    solana_test_validator::{TestValidator, TestValidatorGenesis},
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    },
+    tokio::time::sleep,
+};
+
+struct SlotEstimationAccuracy {
+    leader_tpu_service: LeaderTpuService,
+    validator: TestValidator,
+    exit: Arc<AtomicBool>,
+}
+
+impl SlotEstimationAccuracy {
+    async fn new() -> Self {
+        let validator = TestValidatorGenesis::default().start_async().await.0;
+        let rpc_client = Arc::new(validator.get_async_rpc_client());
+        let exit = Arc::new(AtomicBool::new(false));
+        let leader_tpu_service = LeaderTpuService::new(
+            rpc_client,
+            &validator.rpc_pubsub_url(),
+            Protocol::QUIC,
+            exit.clone(),
+        )
+        .await
+        .unwrap();
+
+        Self {
+            leader_tpu_service,
+            validator,
+            exit,
+        }
+    }
+}
+
+pub(crate) async fn run(accuracy_threshold: f64, num_samples: usize) {
+    info!("bootstrapping test validator");
+
+    let SlotEstimationAccuracy {
+        mut leader_tpu_service,
+        validator,
+        exit,
+    } = SlotEstimationAccuracy::new().await;
+
+    let sleep_time = Duration::from_millis(DEFAULT_MS_PER_SLOT);
+    let mut result_pairs = vec![];
+
+    let mut actual = validator.current_slot();
+    while (actual as usize) < num_samples {
+        actual = validator.current_slot();
+        let estimated = leader_tpu_service.estimated_current_slot();
+        result_pairs.push((estimated, actual));
+        info!(
+            "estimated: {}, actual: {} {}",
+            estimated,
+            actual,
+            if estimated == actual { "✅" } else { "❌" }
+        );
+
+        sleep(sleep_time).await;
+    }
+
+    let failure_rate =
+        result_pairs.iter().filter(|(a, b)| a != b).count() as f64 / result_pairs.len() as f64;
+
+    info!(
+        "failure rate: {failure_rate} <= {accuracy_threshold} {}",
+        if failure_rate <= accuracy_threshold {
+            "✅"
+        } else {
+            "❌"
+        }
+    );
+
+    info!("cleaning up and exiting...");
+
+    exit.store(true, Ordering::Relaxed);
+    leader_tpu_service.join().await;
+}

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -21,7 +21,7 @@ use {
         response::{RpcContactInfo, SlotUpdate},
     },
     solana_sdk::{
-        clock::Slot,
+        clock::{Slot, DEFAULT_MS_PER_SLOT},
         commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
         pubkey::Pubkey,
@@ -784,48 +784,27 @@ impl LeaderTpuService {
         pubsub_client: Option<PubsubClient>,
         exit: Arc<AtomicBool>,
     ) -> Result<()> {
-        let (mut notifications, unsubscribe) = if let Some(pubsub_client) = &pubsub_client {
-            let (notifications, unsubscribe) = pubsub_client.slot_updates_subscribe().await?;
-            (Some(notifications), Some(unsubscribe))
-        } else {
-            (None, None)
-        };
-        let mut last_cluster_refresh = Instant::now();
-        let mut sleep_ms = 1000;
-        loop {
-            if exit.load(Ordering::Relaxed) {
-                if let Some(unsubscribe) = unsubscribe {
-                    (unsubscribe)().await;
-                }
-                // `notifications` requires a valid reference to `pubsub_client`
-                // so `notifications` must be dropped before moving `pubsub_client`
-                drop(notifications);
-                if let Some(pubsub_client) = pubsub_client {
-                    pubsub_client.shutdown().await.unwrap();
-                };
-                break;
-            }
+        tokio::try_join!(
+            Self::run_slot_watcher(recent_slots.clone(), pubsub_client, exit.clone()),
+            Self::run_cache_refresher(rpc_client, recent_slots, leader_tpu_cache, exit),
+        )?;
 
+        Ok(())
+    }
+
+    async fn run_cache_refresher(
+        rpc_client: Arc<RpcClient>,
+        recent_slots: RecentLeaderSlots,
+        leader_tpu_cache: Arc<RwLock<LeaderTpuCache>>,
+        exit: Arc<AtomicBool>,
+    ) -> Result<()> {
+        let mut last_cluster_refresh = Instant::now();
+        let mut sleep_ms = DEFAULT_MS_PER_SLOT;
+
+        while !exit.load(Ordering::Relaxed) {
             // Sleep a slot before checking if leader cache needs to be refreshed again
             sleep(Duration::from_millis(sleep_ms)).await;
-            sleep_ms = 1000;
-
-            if let Some(notifications) = &mut notifications {
-                while let Ok(Some(update)) =
-                    timeout(Duration::from_millis(10), notifications.next()).await
-                {
-                    let current_slot = match update {
-                        // This update indicates that a full slot was received by the connected
-                        // node so we can stop sending transactions to the leader for that slot
-                        SlotUpdate::Completed { slot, .. } => slot.saturating_add(1),
-                        // This update indicates that we have just received the first shred from
-                        // the leader for this slot and they are probably still accepting transactions.
-                        SlotUpdate::FirstShredReceived { slot, .. } => slot,
-                        _ => continue,
-                    };
-                    recent_slots.record_slot(current_slot);
-                }
-            }
+            sleep_ms = DEFAULT_MS_PER_SLOT;
 
             let cache_update_info = maybe_fetch_cache_info(
                 &leader_tpu_cache,
@@ -847,6 +826,53 @@ impl LeaderTpuService {
                 }
             }
         }
+
+        Ok(())
+    }
+
+    async fn run_slot_watcher(
+        recent_slots: RecentLeaderSlots,
+        pubsub_client: Option<PubsubClient>,
+        exit: Arc<AtomicBool>,
+    ) -> Result<()> {
+        let Some(pubsub_client) = pubsub_client else {
+            return Ok(());
+        };
+
+        let (mut notifications, unsubscribe) = pubsub_client.slot_updates_subscribe().await?;
+        // Time out slot update notification polling at 10ms.
+        //
+        // Rationale is two-fold:
+        // 1. Notifications are an unbounded stream -- polling them will block indefinitely if not
+        //    interrupted, and the exit condition will never be checked. 10ms ensures negligible
+        //    CPU overhead while keeping notification checking timely.
+        // 2. The timeout must be strictly less than the slot time (DEFAULT_MS_PER_SLOT: 400) to
+        //    avoid timeout never being reached. For example, if notifications are received every
+        //    400ms and the timeout is >= 400ms, notifications may theoretically always be available
+        //    before the timeout is reached, resulting in the exit condition never being checked.
+        const SLOT_UPDATE_TIMEOUT: Duration = Duration::from_millis(10);
+
+        while !exit.load(Ordering::Relaxed) {
+            while let Ok(Some(update)) = timeout(SLOT_UPDATE_TIMEOUT, notifications.next()).await {
+                let current_slot = match update {
+                    // This update indicates that a full slot was received by the connected
+                    // node so we can stop sending transactions to the leader for that slot
+                    SlotUpdate::Completed { slot, .. } => slot.saturating_add(1),
+                    // This update indicates that we have just received the first shred from
+                    // the leader for this slot and they are probably still accepting transactions.
+                    SlotUpdate::FirstShredReceived { slot, .. } => slot,
+                    _ => continue,
+                };
+                recent_slots.record_slot(current_slot);
+            }
+        }
+
+        // `notifications` requires a valid reference to `pubsub_client`, so `notifications` must be
+        // dropped before moving `pubsub_client` via `shutdown()`.
+        drop(notifications);
+        unsubscribe().await;
+        pubsub_client.shutdown().await?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
#### Problem

Based on https://github.com/anza-xyz/agave/pull/2067

We don't have visibility into the accuracy of the `TpuClient`s current slot estimation. 

#### Summary of Changes

This adds a CLI tool that can be used to generate a report of the TpuClient's slot estimation accuracy.

<img width="1889" alt="image" src="https://github.com/anza-xyz/agave/assets/845717/e28877f7-aa13-4879-ac85-4949341ccaef">

Implementation note: In order to get an accurate reading of the actual current slot, I had to thread the `PohRecorder` through the test validator. This is facilitated by a `pub fn poh_recorder(&self) -> Arc<RwLock<PohRecorder>>` on the `Validator` instance. My sense is that it may be undesirable to add additional public methods onto core internals for the sake of testing, and I am happy to remove the CLI slot estimation tool if that is the case. Alternatively, if anyone has a recommendation for getting the ground-truth current slot via some other means, I will use that.